### PR TITLE
Support minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ The current DaemonSet points to this specific Docker Hub image:
 
 1. Make sure your Elasticsearch backend is running and can be reach through the hostname _elasticsearch-logging_. This value can be changed in the Yaml file
 
+```
+wget https://github.com/kubernetes/kubernetes/raw/master/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+wget https://github.com/kubernetes/kubernetes/raw/master/cluster/addons/fluentd-elasticsearch/es-service.yaml
+kubectl create -f es-controller.yaml
+kubectl create -f es-service.yaml
+```
+
 2. Deploy the daemonset file from this repository:
 
 ```bash

--- a/fluent-bit-daemonset-elasticsearch.yaml
+++ b/fluent-bit-daemonset-elasticsearch.yaml
@@ -35,6 +35,9 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        - name: minikube
+          mountPath: /mnt/sda1/var/lib/docker/containers
+          readOnly: true
       terminationGracePeriodSeconds: 10
       volumes:
       - name: varlog
@@ -43,3 +46,6 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
+      - name: minikube
+        hostPath:
+          path: /mnt/sda1/var/lib/docker/containers


### PR DESCRIPTION
Maybe there's no point in merging this, but I wanted to document how to make tail input work in minikube (tested on Ubuntu, the mount path will probably differ between systems).