### PR TITLE
Add out_kafka daemonset

### DIFF
--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit
+data:
+  # Configuration files: server, input, filters and output
+  # ======================================================
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     info
+        Daemon        off
+        Parsers_File  parsers.conf
+
+    @INCLUDE input-kubernetes.conf
+    @INCLUDE filter-kubernetes.conf
+    @INCLUDE output-elasticsearch.conf
+
+  input-kubernetes.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*.log
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+  filter-kubernetes.conf: |
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        Kube_URL       https://kubernetes.default.svc:443
+        Merge_JSON_Log On
+
+  output-elasticsearch.conf: |
+    [OUTPUT]
+        Name            es
+        Match           *
+        Host            ${FLUENT_ELASTICSEARCH_HOST}
+        Port            ${FLUENT_ELASTICSEARCH_PORT}
+        Logstash_Format On
+        Retry_Limit     False
+
+  parsers.conf: |
+    [PARSER]
+        Name   apache
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   apache2
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   apache_error
+        Format regex
+        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+    [PARSER]
+        Name   nginx
+        Format regex
+        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   json-test
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+
+    [PARSER]
+        Name        syslog
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -17,7 +17,7 @@ data:
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-elasticsearch.conf
+    @INCLUDE output-kafka.conf
 
   input-kubernetes.conf: |
     [INPUT]
@@ -37,14 +37,13 @@ data:
         Kube_URL       https://kubernetes.default.svc:443
         Merge_JSON_Log On
 
-  output-elasticsearch.conf: |
+  output-kafka.conf: |
     [OUTPUT]
-        Name            es
+        Name           kafka
         Match           *
-        Host            ${FLUENT_ELASTICSEARCH_HOST}
-        Port            ${FLUENT_ELASTICSEARCH_PORT}
-        Logstash_Format On
-        Retry_Limit     False
+        Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        Topic          ops-kube-logs-fluentbit-001
+        Timestamp_Key  @timestamp
 
   parsers.conf: |
     [PARSER]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -44,6 +44,7 @@ data:
         Brokers        bootstrap.kafka:9092
         Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
+        Retry_Limit    false
 
   parsers.conf: |
     [PARSER]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -40,8 +40,8 @@ data:
   output-kafka.conf: |
     [OUTPUT]
         Name           kafka
-        Match           *
-        Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        Match          *
+        Brokers        bootstrap.kafka:9092
         Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
 

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -42,7 +42,7 @@ data:
         Name           kafka
         Match           *
         Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-        Topics         ops-kube-logs-fluentbit-001
+        Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
 
   parsers.conf: |

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -42,7 +42,7 @@ data:
         Name           kafka
         Match           *
         Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-        Topic          ops-kube-logs-fluentbit-001
+        Topics         ops-kube-logs-fluentbit-001
         Timestamp_Key  @timestamp
 
   parsers.conf: |

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:0.12.7
+        env:
+        - name: FLUENT_ELASTICSEARCH_HOST
+          value: "elasticsearch"
+        - name: FLUENT_ELASTICSEARCH_PORT
+          value: "9200"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: mnt
+          mountPath: /mnt
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: mnt
+        hostPath:
+          path: /mnt
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,12 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.12.7
-        env:
-        - name: FLUENT_ELASTICSEARCH_HOST
-          value: "elasticsearch"
-        - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
+        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
+        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
+        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
+        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
+        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:0.12.8
+        env:
+        - name: FLUENT_ELASTICSEARCH_HOST
+          value: "elasticsearch"
+        - name: FLUENT_ELASTICSEARCH_PORT
+          value: "9200"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
+        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
+        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,12 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.12.8
-        env:
-        - name: FLUENT_ELASTICSEARCH_HOST
-          value: "elasticsearch"
-        - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
+        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
+        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
+        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
Based on https://github.com/fluent/fluent-bit/issues/94, currently the dev build from https://github.com/fluent/fluent-bit/issues/94#issuecomment-343615599

A typical record (pretty-printed using jq):
```json
  {
    "kubernetes": {
      "docker_id": "dd50658b5d1110070dfa24511b7c2e6095bc210b7807617bc9c7e9705c64be28",
      "container_name": "fluent-bit",
      "host": "minikube",
      "annotations": {
        "kubernetes.io/created-by": "{\\\"kind\\\":\\\"SerializedReference\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"reference\\\":{\\\"kind\\\":\\\"DaemonSet\\\",\\\"namespace\\\":\\\"logging\\\",\\\"name\\\":\\\"fluent-bit\\\",\\\"uid\\\":\\\"7b5e7b6d-c6ef-11e7-ada5-080027039766\\\",\\\"apiVersion\\\":\\\"extensions\\\",\\\"resourceVersion\\\":\\\"1695\\\"}}\\n"
      },
      "labels": {
        "version": "v1",
        "pod-template-generation": "1",
        "kubernetes.io/cluster-service": "true",
        "k8s-app": "fluent-bit-logging",
        "controller-revision-hash": "2050036262"
      },
      "pod_id": "af021eb0-c6ef-11e7-ada5-080027039766",
      "namespace_name": "logging",
      "pod_name": "fluent-bit-qpz69"
    },
    "time": "2017-11-11T15:00:40.427239619Z",
    "stream": "stderr",
    "log": "[2017/11/11 15:00:40] [error] [out_kafka] fluent-bit#producer-1: [thrd:kafka-1.broker.kafka.svc.cluster.local:9092/bootstrap]: kafka-1.broker.kafka.svc.cluster.local:9092/1: Receive failed: Disconnected\\n",
    "@timestamp": 1510412440.42724
  }
```

Notably, compared to filebeat 6.0.0-rc (https://github.com/Yolean/kubernetes-kafka/pull/88), it contains node name and annotations. Also notably, like filebeat, no key is set.