### PR TITLE
Add out_kafka example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,13 @@ $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernet
 $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
+#### Fluent Bit to Elasticsearch
+
 The next step is to create a ConfigMap that will be used by our Fluent Bit DaemonSet:
 
 ```
 $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/0.13-dev/output/elasticsearch/fluent-bit-configmap.yaml
 ```
-
-
-#### Fluent Bit to Elasticsearch
 
 Fluent Bit DaemonSet ready to be used with Elasticsearch on a normal Kubernetes Cluster:
 
@@ -63,6 +62,34 @@ If you are using Minikube for testing purposes, use the following alternative Da
 
 ```
 $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/0.13-dev/output/elasticsearch/fluent-bit-ds-minikube.yaml
+```
+
+#### Fluent Bit to Kafka
+
+Kubectl reads files and URLs alike so you can apply the following based on a local clone:
+```bash
+BASE="."
+```
+
+or from a URL:
+```bash
+BASE="https://raw.githubusercontent.com/Yolean/fluent-bit-kubernetes-kafka/out-kafka"
+```
+
+Create namespace and RBAC resources according to Getting started above.
+Then configure your Kafka bootstrap servers string in `$BASE/output/kafka/fluent-bit-configmap.yaml`.
+The default is for [Yolean/kubernetes-kafka](https://github.com/Yolean/kubernetes-kafka).
+
+```
+kubectl apply -f $BASE/output/kafka/fluent-bit-configmap.yaml
+```
+
+Then depending on Kubernetes setup (the hostPath for logs differ slightly):
+
+```
+kubectl apply -f $BASE/output/kafka/fluent-bit-ds-minikube.yaml
+# or
+kubectl apply -f $BASE/output/kafka/fluent-bit-ds.yaml
 ```
 
 ## Details

--- a/output/elasticsearch/fluent-bit-configmap.yaml
+++ b/output/elasticsearch/fluent-bit-configmap.yaml
@@ -39,7 +39,6 @@ data:
         Match               kube.*
         Kube_URL            https://kubernetes.default.svc:443
         Merge_Log           On
-        K8S-Logging.Parser  On
 
   output-elasticsearch.conf: |
     [OUTPUT]

--- a/output/elasticsearch/fluent-bit-configmap.yaml
+++ b/output/elasticsearch/fluent-bit-configmap.yaml
@@ -39,6 +39,7 @@ data:
         Match               kube.*
         Kube_URL            https://kubernetes.default.svc:443
         Merge_Log           On
+        K8S-Logging.Parser  On
 
   output-elasticsearch.conf: |
     [OUTPUT]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit
+data:
+  # Configuration files: server, input, filters and output
+  # ======================================================
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     info
+        Daemon        off
+        Parsers_File  parsers.conf
+
+    @INCLUDE input-kubernetes.conf
+    @INCLUDE filter-kubernetes.conf
+    @INCLUDE output-elasticsearch.conf
+
+  input-kubernetes.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*.log
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+  filter-kubernetes.conf: |
+    [FILTER]
+        Name           kubernetes
+        Match          kube.*
+        Kube_URL       https://kubernetes.default.svc:443
+        Merge_JSON_Log On
+
+  output-elasticsearch.conf: |
+    [OUTPUT]
+        Name            es
+        Match           *
+        Host            ${FLUENT_ELASTICSEARCH_HOST}
+        Port            ${FLUENT_ELASTICSEARCH_PORT}
+        Logstash_Format On
+        Retry_Limit     False
+
+  parsers.conf: |
+    [PARSER]
+        Name   apache
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   apache2
+        Format regex
+        Regex  ^(?<host>[^ ]*) [^ ]* (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^ ]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   apache_error
+        Format regex
+        Regex  ^\[[^ ]* (?<time>[^\]]*)\] \[(?<level>[^\]]*)\](?: \[pid (?<pid>[^\]]*)\])?( \[client (?<client>[^\]]*)\])? (?<message>.*)$
+
+    [PARSER]
+        Name   nginx
+        Format regex
+        Regex ^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*?)(?: +\S*)?)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?$
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name   json-test
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        Time_Keep   On
+
+    [PARSER]
+        Name        syslog
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -17,7 +17,7 @@ data:
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
-    @INCLUDE output-elasticsearch.conf
+    @INCLUDE output-kafka.conf
 
   input-kubernetes.conf: |
     [INPUT]
@@ -37,14 +37,13 @@ data:
         Kube_URL       https://kubernetes.default.svc:443
         Merge_JSON_Log On
 
-  output-elasticsearch.conf: |
+  output-kafka.conf: |
     [OUTPUT]
-        Name            es
+        Name           kafka
         Match           *
-        Host            ${FLUENT_ELASTICSEARCH_HOST}
-        Port            ${FLUENT_ELASTICSEARCH_PORT}
-        Logstash_Format On
-        Retry_Limit     False
+        Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        Topic          ops-kube-logs-fluentbit-001
+        Timestamp_Key  @timestamp
 
   parsers.conf: |
     [PARSER]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -44,6 +44,7 @@ data:
         Brokers        bootstrap.kafka:9092
         Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
+        Retry_Limit    false
 
   parsers.conf: |
     [PARSER]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -40,8 +40,8 @@ data:
   output-kafka.conf: |
     [OUTPUT]
         Name           kafka
-        Match           *
-        Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
+        Match          *
+        Brokers        bootstrap.kafka:9092
         Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
 

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -42,7 +42,7 @@ data:
         Name           kafka
         Match           *
         Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-        Topics         ops-kube-logs-fluentbit-001
+        Topics         ops.kube-logs-fluentbit.stream.json.001
         Timestamp_Key  @timestamp
 
   parsers.conf: |

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -14,6 +14,9 @@ data:
         Log_Level     info
         Daemon        off
         Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
@@ -32,10 +35,11 @@ data:
 
   filter-kubernetes.conf: |
     [FILTER]
-        Name           kubernetes
-        Match          kube.*
-        Kube_URL       https://kubernetes.default.svc:443
-        Merge_JSON_Log On
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Merge_Log           On
+        K8S-Logging.Parser  On
 
   output-kafka.conf: |
     [OUTPUT]

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -42,7 +42,7 @@ data:
         Name           kafka
         Match           *
         Brokers        kafka-0.broker.kafka.svc.cluster.local:9092,kafka-1.broker.kafka.svc.cluster.local:9092,kafka-2.broker.kafka.svc.cluster.local:9092
-        Topic          ops-kube-logs-fluentbit-001
+        Topics         ops-kube-logs-fluentbit-001
         Timestamp_Key  @timestamp
 
   parsers.conf: |

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -1,0 +1,55 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:0.12.7
+        env:
+        - name: FLUENT_ELASTICSEARCH_HOST
+          value: "elasticsearch"
+        - name: FLUENT_ELASTICSEARCH_PORT
+          value: "9200"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: mnt
+          mountPath: /mnt
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: mnt
+        hostPath:
+          path: /mnt
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,12 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.12.7
-        env:
-        - name: FLUENT_ELASTICSEARCH_HOST
-          value: "elasticsearch"
-        - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
+        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
+        image: fluent/fluent-bit-0.13-dev:0.4
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -14,10 +14,16 @@ spec:
         k8s-app: fluent-bit-logging
         version: v1
         kubernetes.io/cluster-service: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2020"
+        prometheus.io/path: /api/v1/metrics/prometheus
     spec:
       containers:
       - name: fluent-bit
         image: fluent/fluent-bit-0.13-dev:0.4
+        ports:
+        - containerPort: 2020
         resources:
           requests:
             cpu: 2m

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
+        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
+        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
+        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
+        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -18,6 +18,13 @@ spec:
       containers:
       - name: fluent-bit
         image: fluent/fluent-bit-0.13-dev:0.4
+        resources:
+          requests:
+            cpu: 2m
+            memory: 5Mi
+          limits:
+            cpu: 10m
+            memory: 10Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:0.12.8
+        env:
+        - name: FLUENT_ELASTICSEARCH_HOST
+          value: "elasticsearch"
+        - name: FLUENT_ELASTICSEARCH_PORT
+          value: "9200"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
+        image: fluent/fluent-bit-0.13-dev:0.4
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -18,6 +18,13 @@ spec:
       containers:
       - name: fluent-bit
         image: fluent/fluent-bit-0.13-dev:0.4
+        resources:
+          requests:
+            cpu: 5m
+            memory: 10Mi
+          limits:
+            cpu: 50m
+            memory: 20Mi
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -14,10 +14,16 @@ spec:
         k8s-app: fluent-bit-logging
         version: v1
         kubernetes.io/cluster-service: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2020"
+        prometheus.io/path: /api/v1/metrics/prometheus
     spec:
       containers:
       - name: fluent-bit
         image: fluent/fluent-bit-0.13-dev:0.4
+        ports:
+        - containerPort: 2020
         resources:
           requests:
             cpu: 5m

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
+        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
+        image: fluent/fluent-bit-kafka-dev@sha256:fffec8f663d17b0e121132f59e552e8ed88b48c801c4cec520433e6cb2f56d24
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,12 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.12.8
-        env:
-        - name: FLUENT_ELASTICSEARCH_HOST
-          value: "elasticsearch"
-        - name: FLUENT_ELASTICSEARCH_PORT
-          value: "9200"
+        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev@sha256:35fbfb4238f6f2d384fe303d6b5c153c521a237414d423c1f8074a819b4b1170
+        image: fluent/fluent-bit-kafka-dev@sha256:34af750c4448876932c63967d9f5451295b0edb522a0595cd187e8286482598d
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit-kafka-dev:0.4@sha256:97621767bbe271cdda04c25702f57dc5e256ccddcf89386b1d6f539af74c46e6
+        image: fluent/fluent-bit-kafka-dev:0.5@sha256:8f651e4e03239bcd758bffdcc7d16eba38d5e96876757e6ccff29b4eff2e3241
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
This is a rebase of #11. In addition:
 * Adds example memory limits.
 * Adds annotations for the new prometheus exporter feature.