### PR TITLE
Add liveness and readiness probe

### DIFF
--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -26,6 +26,10 @@ spec:
         image: fluent/fluent-bit-0.13-dev:0.7
         ports:
         - containerPort: 2020
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 2020
         resources:
           requests:
             cpu: 2m

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -26,6 +26,10 @@ spec:
         image: fluent/fluent-bit-0.13-dev:0.7
         ports:
         - containerPort: 2020
+        readinessProbe:
+          httpGet:
+            path: /api/v1/metrics/prometheus
+            port: 2020
         livenessProbe:
           httpGet:
             path: /

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -26,6 +26,10 @@ spec:
         image: fluent/fluent-bit-0.13-dev:0.7
         ports:
         - containerPort: 2020
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 2020
         resources:
           requests:
             cpu: 5m

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -26,6 +26,10 @@ spec:
         image: fluent/fluent-bit-0.13-dev:0.7
         ports:
         - containerPort: 2020
+        readinessProbe:
+          httpGet:
+            path: /api/v1/metrics/prometheus
+            port: 2020
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Usefulness:
 * Kill and restart any fluent-bit pod that looks dead, as judged by the capacity to respond to http. (I'm yet to see this happen though, but it's good practice in the k8s world)
 * Halt/abort rolling upgrades, started  by manifest or image apply, if the first restarted pod looks unhealthy.