### PR TITLE
Elasticsearch output - prevent index collisions

### DIFF
--- a/output/elasticsearch/fluent-bit-configmap.yaml
+++ b/output/elasticsearch/fluent-bit-configmap.yaml
@@ -48,6 +48,7 @@ data:
         Host            ${FLUENT_ELASTICSEARCH_HOST}
         Port            ${FLUENT_ELASTICSEARCH_PORT}
         Logstash_Format On
+        Replace_Dots    On
         Retry_Limit     False
 
   parsers.conf: |


### PR DESCRIPTION
This happens when there are different label types, eg: `app: web` and `app.kubernetes.io/name: db`.
For new users it would be safer to have `Replace_Dots On` as the default.
See: https://github.com/fluent/fluent-bit/issues/854

Signed-off-by: Karl Skewes <karl.skewes@gmail.com>