### PR TITLE
Use KUBERNETES_SERVICE_* environment

### DIFF
--- a/output/elasticsearch/fluent-bit-configmap.yaml
+++ b/output/elasticsearch/fluent-bit-configmap.yaml
@@ -37,7 +37,7 @@ data:
     [FILTER]
         Name                kubernetes
         Match               kube.*
-        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Kube_URL            https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}
         Merge_Log           On
         K8S-Logging.Parser  On
 

--- a/output/kafka/fluent-bit-configmap.yaml
+++ b/output/kafka/fluent-bit-configmap.yaml
@@ -37,7 +37,7 @@ data:
     [FILTER]
         Name                kubernetes
         Match               kube.*
-        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Kube_URL            https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}
         Merge_Log           On
         K8S-Logging.Parser  On
 


### PR DESCRIPTION
The Kubernetes API Server host and port could be non-default or restricted across namespaces.  The cluster domain may not be `cluster.local` and Network Policies may restrict access.  The KUBERNETES_SERVICE_* environment variables always contain the correct host and port for the cluster.