### PR TITLE
Adds "wildcard tolerations"

### DIFF
--- a/output/elasticsearch/fluent-bit-ds-minikube.yaml
+++ b/output/elasticsearch/fluent-bit-ds-minikube.yaml
@@ -60,3 +60,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/output/elasticsearch/fluent-bit-ds.yaml
+++ b/output/elasticsearch/fluent-bit-ds.yaml
@@ -54,3 +54,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -72,3 +72,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -66,3 +66,7 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"


### PR DESCRIPTION
to fix an issue with node taints causing the DaemonSet resource to under-report DESIRED while in fact fluent-bit was scheduled on all nodes.

The issue was that we got Prometheus(-operator) alerts that 

Kubectl displayed the daemonset as
```
NAMESPACE     NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                  AGE
logging       fluent-bit                 15        15        15      15           15          <none>                                         58d
monitoring    node-exporter              18        18        18      18           18          <none>                                         222d
```

.. while in fact we had 18 fluent-bit pods.

With this patch we have all numbers at 18.

The solution is based on
https://github.com/kubernetes/kubernetes/blame/v1.12.2/cluster/addons/kube-proxy/kube-proxy-ds.yaml#L31. I'm not sure if all three tolerations are needed.