### PR TITLE
update to 1.0.4 images and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kubernetes Logging with Fluent Bit v0.13
+# Kubernetes Logging with Fluent Bit v1.0.4
 
 
 

--- a/output/elasticsearch/fluent-bit-ds-minikube.yaml
+++ b/output/elasticsearch/fluent-bit-ds-minikube.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.14.9
+        image: fluent/fluent-bit:1.0.4
         imagePullPolicy: Always
         ports:
           - containerPort: 2020

--- a/output/elasticsearch/fluent-bit-ds.yaml
+++ b/output/elasticsearch/fluent-bit-ds.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.14.9
+        image: fluent/fluent-bit:1.0.4
         imagePullPolicy: Always
         ports:
           - containerPort: 2020

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.14.9
+        image: fluent/fluent-bit:1.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 2020

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: fluent/fluent-bit:0.14.9
+        image: fluent/fluent-bit:1.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 2020


### PR DESCRIPTION
with Fluent Bit at 1.0.4 makes sense for k8s daemonset to pull the latest images now from the old 0.14.9
