### PR TITLE
Added security context constraints for deploying on openshift

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernet
 $ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-role-binding.yaml
 ```
 
+If you are deploying fluent-bit on openshift, you additionally need to run:
+
+```
+$ kubectl create -f https://raw.githubusercontent.com/fluent/fluent-bit-kubernetes-logging/master/fluent-bit-openshift-security-context-constraints.yaml
+```
+
 #### Fluent Bit to Elasticsearch
 
 The next step is to create a ConfigMap that will be used by our Fluent Bit DaemonSet:

--- a/fluent-bit-openshift-security-context-constraints.yaml
+++ b/fluent-bit-openshift-security-context-constraints.yaml
@@ -1,0 +1,36 @@
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: logging
+allowPrivilegedContainer: true
+allowHostNetwork: true
+allowHostDirVolumePlugin: true
+priority:
+allowedCapabilities: []
+allowHostPorts: true
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  - system:serviceaccount:logging:builder
+  - system:serviceaccount:logging:default
+  - system:serviceaccount:logging:deployer
+  - system:serviceaccount:logging:fluent-bit


### PR DESCRIPTION
Openshift needs some special security context constraints which are added in this PR. Deployment has been tested with this new configs on OKD 3.11.