### PR TITLE
Updated ds to apps/v1

### DIFF
--- a/fluent-bit-daemonset-kafka-rest.yml
+++ b/fluent-bit-daemonset-kafka-rest.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/elasticsearch/fluent-bit-ds-minikube.yaml
+++ b/output/elasticsearch/fluent-bit-ds-minikube.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/elasticsearch/fluent-bit-ds.yaml
+++ b/output/elasticsearch/fluent-bit-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -10,6 +10,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -10,6 +10,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:


### PR DESCRIPTION
Hello,

Your DaemonSets should now use the apps/v1 apiVersion in order to work on recent Kubernetes versions (1.17 in my case).

Signed-off-by: David Calvert <davidcalvertfr@gmail.com>