### PR TITLE
Update daemonset for k8s 1.16

### DIFF
--- a/output/elasticsearch/fluent-bit-ds.yaml
+++ b/output/elasticsearch/fluent-bit-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,11 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
+      version: v1
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:


### PR DESCRIPTION
The [docs](https://docs.fluentbit.io/manual/installation/kubernetes) has a "Note for Kubernetes < v1.16", so I think maybe this file should be for k8s 1.16