### PR TITLE
Switch to apps/v1 for DaemonSet

### DIFF
--- a/fluent-bit-daemonset-kafka-rest.yml
+++ b/fluent-bit-daemonset-kafka-rest.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/elasticsearch/fluent-bit-ds-minikube.yaml
+++ b/output/elasticsearch/fluent-bit-ds-minikube.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/elasticsearch/fluent-bit-ds.yaml
+++ b/output/elasticsearch/fluent-bit-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -8,6 +8,9 @@ metadata:
     version: v1
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/kafka/fluent-bit-ds-minikube.yaml
+++ b/output/kafka/fluent-bit-ds-minikube.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -10,6 +10,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:

--- a/output/kafka/fluent-bit-ds.yaml
+++ b/output/kafka/fluent-bit-ds.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluent-bit
@@ -10,6 +10,9 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit-logging
   template:
     metadata:
       labels:


### PR DESCRIPTION
https://docs.fluentbit.io/manual/installation/kubernetes#note-for-kubernetes-less-than-v-1-16 suggests that all of these files have been converted for Kubernetes >=1.14 (deprecated in 1.14). Given that 1.14 is past community support, it seems like we should switch these to `apps/v1`.